### PR TITLE
fix: improve game process selection logic to avoid launcher stub

### DIFF
--- a/Services/GameProcessService.cs
+++ b/Services/GameProcessService.cs
@@ -56,7 +56,7 @@ public sealed class GameProcessService : IDisposable
             if (_process is { HasExited: false })
                 return;
 
-            _process = Process.GetProcessesByName(ProcessName).FirstOrDefault();
+            _process = SelectGameProcess();
             var nowAttached = IsAttached;
             if (was != nowAttached)
             {
@@ -75,6 +75,62 @@ public sealed class GameProcessService : IDisposable
             }
         }
         catch (Exception ex) { _log.Error($"GameProcess poll error: {ex.Message}"); }
+    }
+
+    /// <summary>
+    /// FH6 runs TWO processes named "forzahorizon6": a small launcher/bootstrapper
+    /// stub (~672 KB main module, idle) and the real game (hundreds of MB, burns CPU).
+    /// FirstOrDefault() can pick the stub, so the CRC/AOB scan runs over a module that
+    /// doesn't contain the game code → "signature not found".
+    /// Pick the process whose main module is largest; on ties / unreadable modules,
+    /// fall back to the one with the most CPU time.
+    /// </summary>
+    private Process? SelectGameProcess()
+    {
+        var candidates = Process.GetProcessesByName(ProcessName);
+        if (candidates.Length == 0) return null;
+        if (candidates.Length == 1) return candidates[0];
+
+        Process? best = null;
+        long bestScore = -1;
+
+        foreach (var p in candidates)
+        {
+            long size = 0;
+            try { size = p.MainModule?.ModuleMemorySize ?? 0; } catch { /* UWP/denied */ }
+
+            // Primary key: main module size. Secondary (when size unreadable / equal):
+            // total processor time. Both pick the real engine over the idle stub.
+            long score = size;
+            if (score <= 0)
+            {
+                try { score = (long)p.TotalProcessorTime.TotalMilliseconds; } catch { score = 0; }
+            }
+
+            if (score > bestScore)
+            {
+                bestScore = score;
+                best = p;
+            }
+        }
+
+        // Reject an obvious stub (< 50 MB) so the 2s poll keeps retrying until the
+        // real engine module is mapped, instead of attaching to the launcher.
+        if (best is not null)
+        {
+            try
+            {
+                var sz = best.MainModule?.ModuleMemorySize ?? 0;
+                if (sz is > 0 and < 50 * 1024 * 1024)
+                {
+                    _log.Error($"Only a small ({sz / 1024} KB) FH6 module is visible — likely the launcher stub. Waiting for the real game process...");
+                    return null;
+                }
+            }
+            catch { /* module unreadable (UWP) — accept best, native fallback handles it */ }
+        }
+
+        return best;
     }
 
     public List<string> DetectConflictingTrainers()


### PR DESCRIPTION
## Fix: attach to the real FH6 process, not the launcher stub

### Problem
FH6, in some istances, runs **two** processes named `forzahorizon6.exe`: a small launcher/bootstrapper
stub and the actual game engine. The previous detection logic used
`Process.GetProcessesByName("ForzaHorizon6").FirstOrDefault()`, which can return the
**stub** instead of the game.

When that happens, the AOB scan runs over the stub's tiny main module — which does not
contain the game code — so the CRC signature is never found and **every runtime-hook
cheat fails** with: CRC bypass signature not found (FH6 likely updated).
The misleading "FH6 likely updated" message sent people chasing a signature rewrite when
the real cause was attaching to the wrong process. This likely explains issues #1
("Not all cheats work") and #2 ("Skill points not working").

### Root cause
`FirstOrDefault()` is order-based, so the launcher (which is often listed first and stays
idle) gets picked over the real engine.

### Fix
Replaced `FirstOrDefault()` with a new `SelectGameProcess()` helper that:

- Picks the `forzahorizon6` process with the **largest main module** (the real engine is
  hundreds of MB; the stub is ~672 KB).
- Falls back to **total CPU time** as a tiebreaker for UWP/Xbox builds where the module
  size isn't readable.
- **Rejects any module smaller than 50 MB**, returning `null` so the 2s poll keeps
  retrying until the real engine is mapped — instead of attaching to the stub. This also
  handles the case where the launcher starts first and the game process appears a few
  seconds later.

### Testing
Same machine, Steam build, FH6 in Free Roam:

| | Main module | Result |
|---|---|---|
| **Before** | `688128 bytes` (≈672 KB stub) | CRC signature not found, all cheats fail |
| **After** | `187715584 bytes` (≈179 MB engine) | Attaches to the correct process, CRC scan proceeds |

### Notes
- No behavior change for setups exposing only one `forzahorizon6` process — `SelectGameProcess()`
  short-circuits and returns it directly.
- The 50 MB threshold is a heuristic chosen to separate the launcher stub from the AAA
  game module; trivially adjustable if a future patch changes the stub size.